### PR TITLE
Fix MQTT connection with recent Mosquito broker (Eclipse 6.2.0)

### DIFF
--- a/src/mqttclient.py
+++ b/src/mqttclient.py
@@ -86,7 +86,7 @@ class MQTTClient2(object):
         global _conn_errors
         if self.mqtt_client is None:
             log.info("create mqtt client {0}".format(self.server))
-            self.mqtt_client = MQTTClient(HOST_NAME, self.server, user=self.user, password=self.password)
+            self.mqtt_client = MQTTClient(HOST_NAME, self.server, user=self.user, password=self.password, keepalive=30)
         if wlan.status() == network.STAT_GOT_IP:
             try:
                 print("connecting to mqtt server {0}".format(self.server))


### PR DESCRIPTION
Yesterday morning, my MQTT connection to Home Assistant - and more specifically the Eclipse Mosquito broker stopped working. It was raising `MQTT server error 2: server address or network` and subsequently got stuck with failing ping()'s.

After some troubleshooting, it seems the update the Eclipse Mosquito broker version 6.2.0 caused this. This version needs a `keepalive` to be set, so this commit introduces that.

Works perfectly after this small fix! Thanks @Josverl 