### PR TITLE
Fix Error maximum recursion depth exceeded

### DIFF
--- a/src/p1meter.py
+++ b/src/p1meter.py
@@ -170,24 +170,27 @@ class P1Meter():
         "split the received data into readings(meter, reading, unit)"
         readings = []
         for line in newdata:
-            out = re.match('(.*?)\((.*)\)', line)           #pylint: disable=anomalous-backslash-in-string
-            if out:
-                lineinfo = {'meter': out.group(1), 'reading':None, 'unit': None}
+            try:
+                out = re.match('(.*?)\((.*)\)', line)           #pylint: disable=anomalous-backslash-in-string
+                if out:
+                    lineinfo = {'meter': out.group(1), 'reading':None, 'unit': None}
 
-                reading = out.group(2).split('*')
-                if len(reading) == 2:
-                    lineinfo['reading'] = reading[0]
-                    lineinfo['unit'] = reading[1]
-                else:
-                    lineinfo['reading'] = reading[0]
-                # a few meters have compound content, that remain seperated by `)(`
-                # split and use  only the last section (ie gas meter reading)
-                lineinfo['reading'] = lineinfo['reading'].split(')(')[-1]
-                if VERBOSE:
-                    log.debug(lineinfo)
-                readings.append(lineinfo)
+                    reading = out.group(2).split('*')
+                    if len(reading) == 2:
+                        lineinfo['reading'] = reading[0]
+                        lineinfo['unit'] = reading[1]
+                    else:
+                        lineinfo['reading'] = reading[0]
+                    # a few meters have compound content, that remain seperated by `)(`
+                    # split and use  only the last section (ie gas meter reading)
+                    lineinfo['reading'] = lineinfo['reading'].split(')(')[-1]
+                    if VERBOSE:
+                        log.debug(lineinfo)
+                    readings.append(lineinfo)
+            except Exception as e:                                   #pylint: disable=broad-except
+                log.debug(f"Error {e} processsing line: {line}")
         return readings
-
+    
     async def process(self, tele: dict):
         # check CRC
         if not self.crc_ok(tele):


### PR DESCRIPTION
Fix error **maximum recursion depth exceeded** 
for long line like: 1-0:99.97.0(7)(0-0:96.7.19)(240219182858W)(0000004612*s)(231004090359S)(0
000007058*s)(221222100300W)(0000005194*s)(220204115824W)(0000008460*s)(211210183258W)(0000005203*s)(211210170510W)(0000012102*s)(000101000001W)(2147483647*s)                                                                                                                                               

Note the error is not easily spotted as it results in some out of memory error or wifi disconnections